### PR TITLE
Fix for three.js >= r102

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,7 +151,8 @@ class GPUComputationRenderer {
     }
     doRenderTarget(material, output) {
         this.mesh.material = material;
-        this.renderer.render(this.scene, this.camera, output);
+        this.renderer.setRenderTarget(output);
+        this.renderer.render(this.scene, this.camera);
         this.mesh.material = this.passThruShader;
     }
     renderTexture(input, output) {

--- a/index.js
+++ b/index.js
@@ -151,8 +151,10 @@ class GPUComputationRenderer {
     }
     doRenderTarget(material, output) {
         this.mesh.material = material;
+        const previousRenderTarget = this.renderer.getRenderTarget();
         this.renderer.setRenderTarget(output);
         this.renderer.render(this.scene, this.camera);
+        this.renderer.setRenderTarget(previousRenderTarget);
         this.mesh.material = this.passThruShader;
     }
     renderTexture(input, output) {

--- a/index.ts
+++ b/index.ts
@@ -371,8 +371,10 @@ export class GPUComputationRenderer {
 
     public doRenderTarget(material: ShaderMaterial, output: RenderTarget) {
         this.mesh.material = material;
+        const previousRenderTarget = this.renderer.getRenderTarget();
 		this.renderer.setRenderTarget(output);
         this.renderer.render(this.scene, this.camera);
+        this.renderer.setRenderTarget(previousRenderTarget);
         this.mesh.material = this.passThruShader;
     }
 

--- a/index.ts
+++ b/index.ts
@@ -371,7 +371,8 @@ export class GPUComputationRenderer {
 
     public doRenderTarget(material: ShaderMaterial, output: RenderTarget) {
         this.mesh.material = material;
-        this.renderer.render(this.scene, this.camera, output);
+		this.renderer.setRenderTarget(output);
+        this.renderer.render(this.scene, this.camera);
         this.mesh.material = this.passThruShader;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,10 +4,17 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
-        "@types/three": {
-            "version": "0.93.20",
-            "resolved": "https://registry.npmjs.org/@types/three/-/three-0.93.20.tgz",
-            "integrity": "sha512-k+YNaO8Ux6b2UQBIwM/fa4fdnBJpsMSxrHVGHXFsoflFUkvy/TPnvMXj396l1VjzzjqFX/vJFEsrYwpUhztD2g=="
+        "three": {
+            "version": "0.116.1",
+            "resolved": "https://registry.npmjs.org/three/-/three-0.116.1.tgz",
+            "integrity": "sha512-l2JCMiA/lVZAuSrLWRYMalvpR+0j8hbIhCpfs4V6JFnw2+JQEQJ5HltNpfFr+9TDpQts1BhtcISehWf/xBGPvQ==",
+            "dev": true
+        },
+        "typescript": {
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+            "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+            "dev": true
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -22,9 +22,10 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "peerDependencies": {
-        "three": ">=0.94.0"
+        "three": ">=0.116.0"
     },
     "devDependencies": {
-        "@types/three": "^0.93.20"
+        "three": "^0.116.1",
+        "typescript": "^3.8.3"
     }
 }


### PR DESCRIPTION
Library doesn't work for newer versions of threejs, because the renderTarget paramter [was removed in v102](https://github.com/mrdoob/three.js/wiki/Migration-Guide#r101--r102).

- Replaced the render paramter with two setRenderTarget calls to mimic the old behavior
- Updated threejs version
  - Added three as a dev-dependency to get the updated types during development.
  - Added typescript to dependencies, to not rely on a global installation.